### PR TITLE
Set up CI config

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,12 @@
+name: CI
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run tests in Docker
+        run: docker-compose -f docker-compose.test.yml up --exit-code-from=test
+

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,20 @@
+version: '3.7'
+
+services:
+  # Application
+  test:
+    image: nhsx:latest
+    environment:
+      - DJANGO_SECRET_KEY=entersecretkeyhere
+    restart: always
+    build:
+      context: ./
+      target: app
+      dockerfile: ./docker/web/Dockerfile
+      args:
+        - SERVER_ENV=test
+    volumes:
+      - ./app/:/usr/srv/app:Z
+      - ./app/media:/usr/srv/app/media:Z
+
+    command: pytest -s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.7'
 
 services:
   # Postgres
@@ -37,6 +37,7 @@ services:
     restart: always
     build:
       context: ./
+      target: dev
       dockerfile: ./docker/web/Dockerfile
       args:
         - SERVER_ENV=development

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.7 as base
 
 ENV VERSION 1.9.1
 
@@ -49,19 +49,6 @@ RUN apk update && apk add --no-cache \
     rm -f /tmp/* /etc/apk/cache/* /root/.cache
 
 ####################################################################################################
-# Install latest Fish shell from source
-####################################################################################################
-
-WORKDIR /tmp
-RUN wget https://github.com/fish-shell/fish-shell/releases/download/3.1.0/fish-3.1.0.tar.gz && \
-    tar -xvzf fish-3.1.0.tar.gz && \
-    cd fish-3.1.0 && \
-    cmake . && \
-    make && \
-    make install && \
-    rm -rf /tmp/*
-
-####################################################################################################
 # Install static asset compilers
 ####################################################################################################
 
@@ -80,28 +67,7 @@ RUN pip install --no-cache-dir \
     libsass \
     closure
 
-ENV SHELL /bin/zsh
-
-# Install oh-my-zsh and set zsh as the default shell
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
-
-COPY ./docker/web/conf/zshrc /tmp/.zshrc
-COPY ./docker/web/conf/hactar.zsh-theme /tmp/hactar.zsh-theme
-COPY ./docker/web/conf/zsh-auto-suggest.cfg /tmp/config.zsh
-
-RUN mv /tmp/.zshrc ~/.zshrc && \
-    mv /tmp/hactar.zsh-theme ~/.oh-my-zsh/themes/hactar.zsh-theme && \
-    mv /tmp/config.zsh ~/.oh-my-zsh/custom/config.zsh && \
-    git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions && \
-    rm -rf /tmp/*
-
-
-CMD ["zsh", "--version"]
-
-# Add fish config
-RUN mkdir -p ~/.config/fish
-COPY ./docker/web/conf/config.fish /tmp/config.fish
-RUN mv /tmp/config.fish ~/.config/fish/config.fish
+FROM base AS app
 
 # Install envkey-source
 RUN curl -s https://raw.githubusercontent.com/envkey/envkey-source/master/install.sh | bash
@@ -161,6 +127,44 @@ RUN apk update && \
 # Expose the dev server
 EXPOSE 5000
 
+FROM app as dev
+
+####################################################################################################
+# Install latest Fish shell from source
+####################################################################################################
+
+WORKDIR /tmp
+RUN wget https://github.com/fish-shell/fish-shell/releases/download/3.1.0/fish-3.1.0.tar.gz && \
+    tar -xvzf fish-3.1.0.tar.gz && \
+    cd fish-3.1.0 && \
+    cmake . && \
+    make && \
+    make install && \
+    rm -rf /tmp/*
+
+ENV SHELL /bin/zsh
+
+# Install oh-my-zsh and set zsh as the default shell
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+
+COPY ./docker/web/conf/zshrc /tmp/.zshrc
+COPY ./docker/web/conf/hactar.zsh-theme /tmp/hactar.zsh-theme
+COPY ./docker/web/conf/zsh-auto-suggest.cfg /tmp/config.zsh
+
+RUN mv /tmp/.zshrc ~/.zshrc && \
+    mv /tmp/hactar.zsh-theme ~/.oh-my-zsh/themes/hactar.zsh-theme && \
+    mv /tmp/config.zsh ~/.oh-my-zsh/custom/config.zsh && \
+    git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions && \
+    rm -rf /tmp/*
+
+CMD ["zsh", "--version"]
+
+# Add fish config
+RUN mkdir -p ~/.config/fish
+COPY ./docker/web/conf/config.fish /tmp/config.fish
+RUN mv /tmp/config.fish ~/.config/fish/config.fish
+
+WORKDIR /usr/srv/app/
 
 # We'll eventually want these or similar for the production container
 # RUN python manage.py migrate


### PR DESCRIPTION
This sets up the CI config to run tests in Github Actions. I've tweaked the Dockerfile and docker-compose setup, so the zsh / fish config isn't run as part of the CI setup, and this shaves about 3 minutes off the build time.

There's probably stuff we can do to speed it up, but I think this is OK for now.