### PR TITLE
Blog post tweaks

### DIFF
--- a/app/modules/blog_posts/models.py
+++ b/app/modules/blog_posts/models.py
@@ -4,7 +4,8 @@ from dal_select2.widgets import ModelSelect2Multiple
 from modelcluster.fields import ParentalKey
 from taggit.models import TaggedItemBase
 from modelcluster.contrib.taggit import ClusterTaggableManager
-from wagtail.admin.edit_handlers import FieldPanel
+from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
+from wagtail.core.models import Page
 
 from modules.core.models.abstract import BasePage, BaseIndexPage, PageAuthorsMixin
 
@@ -44,14 +45,12 @@ class BlogPost(BasePage, PageAuthorsMixin):
 
     tags = ClusterTaggableManager(through=BlogTag, blank=True)
 
-    promote_panels = [
-        *BasePage.page_promote_panels,
-        FieldPanel("tags"),
-        *BasePage.social_promote_panels
-    ]
-    content_panels = BasePage.content_panels + [
+    content_panels = [
+        *Page.content_panels,
         FieldPanel(
             'authors',
             widget=ModelSelect2Multiple(url='author-autocomplete')
-        )
+        ),
+        StreamFieldPanel("body"),
+        FieldPanel("tags"),
     ]

--- a/app/modules/core/models/abstract.py
+++ b/app/modules/core/models/abstract.py
@@ -114,7 +114,7 @@ class PageAuthorsMixin(models.Model):
         abstract = True
     authors = ParentalManyToManyField(
         'users.User',
-        blank=True,
+        blank=False,
         related_name='pages_%(class)s'
     )
 

--- a/app/templates/core/section_page.html
+++ b/app/templates/core/section_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags static wagtailuserbar nhsukfrontend_tags %}
+{% load wagtailcore_tags static wagtailuserbar nhsukfrontend_tags wagtailimages_tags %}
 
 {% block body_class %}template-section{% endblock %}
 


### PR DESCRIPTION
Editing the blog posts, I came across a few tweaks that might make things a bit more uniform.

The editing page for blog posts now looks like this:

![image](https://user-images.githubusercontent.com/109774/78664566-30772e80-78cc-11ea-9490-c68e3fb3c518.png)
