### PR TITLE
Adjust section page subpages by number of links

### DIFF
--- a/app/modules/core/models/pages.py
+++ b/app/modules/core/models/pages.py
@@ -34,6 +34,18 @@ class SectionPage(BasePage, HeroImageContentMixin, SubNavMixin):
         tabs.insert(2, (cls.subnav_panels, 'Subnavigation'))
         return tabs
 
+    def subnav_items_per_row(self):
+        if (len(self.subnav_pages) % 3 == 0):
+            return 3
+        else:
+            return 2
+
+    def subnav_column_class(self):
+        if (len(self.subnav_pages) % 3 == 0):
+           return  "one-third"
+        else:
+            return "one-half"
+
 
 ################################################################################
 # ArticlePage

--- a/app/modules/core/tests/test_section_page.py
+++ b/app/modules/core/tests/test_section_page.py
@@ -60,6 +60,46 @@ def test_section_page_shows_subnav_pages(section_page):
 
     assert "http://example.com" in str(rv.content)
 
+def test_section_page_with_two_page_links_has_half_width(section_page):
+    section_page.automatic = False
+
+    section_page.page_links = json.dumps([
+        LINK_BLOCK,
+        LINK_BLOCK
+    ])
+
+    assert section_page.subnav_items_per_row() == 2
+    assert section_page.subnav_column_class() == "one-half"
+
+def test_section_page_with_three_page_links_has_third_width(section_page):
+    section_page.automatic = False
+
+    section_page.page_links = json.dumps([
+        LINK_BLOCK,
+        LINK_BLOCK,
+        LINK_BLOCK
+    ])
+
+    assert section_page.subnav_items_per_row() == 3
+    assert section_page.subnav_column_class() == "one-third"
+
+def test_section_page_with_four_page_links_has_half_width(section_page):
+    section_page.automatic = False
+
+    section_page.page_links = json.dumps([
+        LINK_BLOCK,
+        LINK_BLOCK,
+        LINK_BLOCK,
+        LINK_BLOCK
+    ])
+    section_page.save_revision().publish()
+
+    assert section_page.subnav_items_per_row() == 2
+    assert section_page.subnav_column_class() == "one-half"
+
+
+
+
 
 
 

--- a/app/templates/core/section_page.html
+++ b/app/templates/core/section_page.html
@@ -12,7 +12,7 @@
 <div class="nhsuk-width-container">
   <main class="nhsuk-main-wrapper" id="maincontent">
     <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-two-thirds">
+      <div class="nhsuk-grid-column-full">
         {% include_block page.body %}
       </div>
     </div>

--- a/app/templates/core/section_page.html
+++ b/app/templates/core/section_page.html
@@ -17,10 +17,10 @@
       </div>
     </div>
 
-    {% for row in page.subnav_pages|chunk:2 %}
+    {% for row in page.subnav_pages|chunk:page.subnav_items_per_row %}
       <div class="nhsuk-grid-row nhsuk-promo-group">
         {% for promo in row %}
-          <div class="nhsuk-grid-column-one-half nhsuk-promo-group__item nhsuk-promo-group__item">
+          <div class="nhsuk-grid-column-{{ page.subnav_column_class }} nhsuk-promo-group__item nhsuk-promo-group__item">
             <div class="nhsuk-promo">
               <a class="nhsuk-promo__link-wrapper" href="{{ promo.url }}">
                 <div class="nhsuk-promo__content">


### PR DESCRIPTION
The designs @isratc has done show that the column size shifts according to the number of links available. This adjusts the number of items per row, and the corresponding class depending on the number of items available.

## Examples

### Three items

![image](https://user-images.githubusercontent.com/109774/78829665-aa97d800-79de-11ea-894a-d5f5e1afe698.png)

### Four items

![image](https://user-images.githubusercontent.com/109774/78829734-c8653d00-79de-11ea-8f30-a567ab98dc9a.png)

### Five items

![image](https://user-images.githubusercontent.com/109774/78829910-124e2300-79df-11ea-925d-a9fe211ce586.png)
