### PR TITLE
Add Google Analytics

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -203,7 +203,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                "django.template.context_processors.static"
+                "django.template.context_processors.static",
+                'wagtail.contrib.settings.context_processors.settings',
             ],
         },
     },

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -36,5 +36,9 @@
         {% block extra_js %}
             {# Override this in templates to add extra javascript #}
         {% endblock %}
+
+        {% if settings.core.AnalyticsSettings.property_id %}
+            <script type="text/javascript" data-cookieconsent="statistics" type="text/plain" src="https://www.googletagmanager.com/gtag/js?id={{ settings.core.AnalyticsSettings.property_id }}"></script>
+        {% endif %}
     </body>
 </html>


### PR DESCRIPTION
This adds Google Analytics via the `AnalyticsSettings` setting in the backend. It also utilises the `data-cookieconsent` from the NHS Cookie Consent JS, so the file only gets loaded if cookies have been enabled.