### PR TITLE
Feature/Update markup for "no results" and section body content

### DIFF
--- a/app/modules/search/templates/search/search.html
+++ b/app/modules/search/templates/search/search.html
@@ -60,7 +60,9 @@
                         </li>
                       {% endif %}
                       {% elif search_query %}
-                      <h4>No results found</h4>
+                      <p>
+                        <h2>No results found</h2>
+                      </p>
                     </ul>
                   </nav>
               </div>

--- a/app/templates/core/section_page.html
+++ b/app/templates/core/section_page.html
@@ -18,7 +18,7 @@
       {%else %}
      <div class="nhsuk-grid-row">
     {% endif %}
-      <div class="nhsuk-grid-column-full">
+      <div class="nhsuk-grid-column-two-thirds">
         {% if hero_image|length == 0 or hero_text|length == 0 %}
           <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">{{ page.title }}</h1>
         {% endif %}


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/1vpgx5TA/133-search-add-markup-to-style-no-results-found-on-search-results
## Changes in this PR:
Search result: Add markup to style No results found on search results
Section page: Change body content markup to "<div class="nhsuk-grid-column-two-thirds">"

## Screenshots of UI changes:
search "no result"
<img width="680" alt="Screenshot 2020-04-14 at 15 18 21" src="https://user-images.githubusercontent.com/10596845/79235195-35575780-7e63-11ea-859c-417fa0ebfbd6.png">

Section page body content:
<img width="1055" alt="Screenshot 2020-04-14 at 15 09 58" src="https://user-images.githubusercontent.com/10596845/79235244-44d6a080-7e63-11ea-8e8a-9c620d0463b5.png">
