### PR TITLE
Sets a fixed height on index page items to close the gaps.

### DIFF
--- a/app/assets/_dev/scss/base/_site.scss
+++ b/app/assets/_dev/scss/base/_site.scss
@@ -4,6 +4,10 @@ figure.nhsuk-image {
     width: 100%;
 }
 
+div.fixed-height{
+    height: 400px;
+}
+
 
 img.richtext-image, img.full-width{
     width: 100%;

--- a/app/templates/core/index_page.html
+++ b/app/templates/core/index_page.html
@@ -42,7 +42,7 @@
         {% endif %}
           {% for post in pages.object_list %}
             {% if post.id not in page.specific.featured_ids %}
-            <div class="nhsuk-grid-column-{{column_size}} nhsuk-u-margin-bottom-5">
+            <div class="nhsuk-grid-column-{{column_size}} nhsuk-u-margin-bottom-5 fixed-height">
               <h3 class="nhsuk-heading-m">
                 <a href="{% pageurl post %}">{{post.title}}</a>
               </h3>


### PR DESCRIPTION
This should close the gaps on the blog index page listings.